### PR TITLE
Remove padding on first line of code fences

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -153,7 +153,7 @@ a{
 }
 
 a:hover{
-    color: var(--green);   
+    color: var(--green);
 }
 
 h1,h2,h3,h4,h5,h6 {
@@ -220,7 +220,7 @@ h6 {
 
 .draft-label{
     color: var(--light-orange);
-    text-decoration: none;    
+    text-decoration: none;
 }
 
 .markdown {
@@ -285,8 +285,7 @@ blockquote {
 }
 
 code {
-    padding: 5px;
-    background-color: var(--bg0_h); 
+    background-color: var(--bg0_h);
 }
 
 img {


### PR DESCRIPTION
This 5px padding only appears to affect the first line of the code
fence, throwing off the formatting of the first line of the code fence a
little.

This removes the padding for the first line and removes trailing
whitespace for other lines.

Before:

![156905272-a0da5adb-ceea-4ff5-ba5e-ecb10aa951ad](https://user-images.githubusercontent.com/5041953/156905469-7a8df98f-a5dd-4beb-b423-cb6bdab54884.png)


After:

![Screen Shot 2022-03-05 at 8 30 52 PM](https://user-images.githubusercontent.com/5041953/156905466-547345ef-aa6c-477c-8a2b-7a1e51a16d7f.png)


This fixes: #3 

This is a great theme. Thanks for all of the work to make it :)

You can see a site in production with this fix enabled at https://blog.darrien.dev 