### PR TITLE
Fixup footnotes and other relative URLs

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,4 @@
 <header>
-    <base href="{{ .Site.BaseURL }}">
     <div>
         <h1 class="site-title"><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h1>
         <div class="site-info">


### PR DESCRIPTION
Looks like keeping this line in breaks relative URLs which causes
anchors to go a little bonkers.

See this identical issue for more info:
https://github.com/ojroques/hugo-researcher/issues/5

For an example of this working in production see: https://blog.darrien.dev/posts/you-dont-know-gif
* Fix pushed to prod via here: https://gitlab.com/dg-website/blog/-/commit/4eb95e62bd10129528f313e62a65dfe8353454e6

If it doesn't work initially, make sure to CTRL/CMD+SHIFT+R for refresh without cache to get the latest. 

This closes #7 